### PR TITLE
Fix #34

### DIFF
--- a/src/components/VueSignaturePad.js
+++ b/src/components/VueSignaturePad.js
@@ -58,12 +58,14 @@ export default {
   },
   methods: {
     resizeCanvas(canvas) {
+      const data = this.signaturePad.toData();
       const ratio = Math.max(window.devicePixelRatio || 1, 1);
       canvas.width = canvas.offsetWidth * ratio;
       canvas.height = canvas.offsetHeight * ratio;
       canvas.getContext('2d').scale(ratio, ratio);
       this.signaturePad.clear();
       this.signatureData = TRANSPARENT_PNG;
+      this.signaturePad.fromData(data);
     },
     saveSignature() {
       const { signaturePad, saveType } = this;


### PR DESCRIPTION
When a screen is rotated or the size is changed. The canvas is resized, this also clear the signature. This change saves the signature temporarily and sets it back when the canvas is changed.