### PR TITLE
refactor(component): add save img type parameter to saveSignature method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Installation
 
 ```sh
-yarn add vue-signature-pad
+$ yarn add vue-signature-pad
 ```
 
 ## Usage
@@ -29,11 +29,7 @@ Vue.use(VueSignaturePad);
 ```vue
 <template>
   <div id="app">
-    <VueSignaturePad
-      width="500px"
-      height="500px"
-      ref="signaturePad"
-    />
+    <VueSignaturePad width="500px" height="500px" ref="signaturePad" />
     <div>
       <button @click="save">Save</button>
       <button @click="undo">Undo</button>
@@ -41,19 +37,19 @@ Vue.use(VueSignaturePad);
   </div>
 </template>
 <script>
-  export default {
-    name: 'MySignaturePad',
-    methods: {
-      undo() {
-        this.$refs.signaturePad.undoSignature();
-      },
-      save() {
-        const { isEmpty, data } = this.$refs.signaturePad.saveSignature();
-        console.log(isEmpty);
-        console.log(data);
-      }
+export default {
+  name: 'MySignaturePad',
+  methods: {
+    undo() {
+      this.$refs.signaturePad.undoSignature();
+    },
+    save() {
+      const { isEmpty, data } = this.$refs.signaturePad.saveSignature();
+      console.log(isEmpty);
+      console.log(data);
     }
   }
+};
 </script>
 ```
 
@@ -80,26 +76,25 @@ export default {
       console.log('=== End ===');
     }
   }
-}
+};
 </script>
 ```
 
 ## Props
 
-| Name        | Type   | Default                                                                                                 | Description                                                     | Example                                                                                                                         |
-| :---------- | :----- | :------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| width       | String | `100%`                                                                                                  | Set the `div` width.                                            | -                                                                                                                               |
-| height      | String | `100%`                                                                                                  | Set the `div` height.                                           | -                                                                                                                               |
-| saveType    | String | `image/png`                                                                                             | Image type, support `image/png`, `image/jpeg`, `image/svg+xml`. | -                                                                                                                               |
-| options     | Object | [Reference](https://github.com/neighborhood999/vue-signature-pad/blob/master/src/utils/index.js#L5-L13) | Set the signature pad options.                                  | [Reference](https://github.com/neighborhood999/vue-signature-pad/blob/master/src/utils/index.js#L5-L13)                         |
-| images      | Array  | `[]`                                                                                                    | Merge signature with the provide images.                        | `['A.png', 'B.png', 'C.png']` or `[{ src: 'A.png', x: 0, y: 0 }, { src: 'B.png', x: 0, y: 10 }, { src: 'C.png', x: 0, y: 20 }]` |
-| customStyle | Object | `{}`                                                                                                    | Custom `div` style.                                             | `{ border: black 3px solid }`                                                                                                   |
+| Name        | Type   | Default                                                                                                 | Description                              | Example                                                                                                                         |
+| :---------- | :----- | :------------------------------------------------------------------------------------------------------ | :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| width       | String | `100%`                                                                                                  | Set the `div` width.                     | -                                                                                                                               |
+| height      | String | `100%`                                                                                                  | Set the `div` height.                    | -                                                                                                                               |
+| options     | Object | [Reference](https://github.com/neighborhood999/vue-signature-pad/blob/master/src/utils/index.js#L5-L13) | Set the signature pad options.           | [Reference](https://github.com/neighborhood999/vue-signature-pad/blob/master/src/utils/index.js#L5-L13)                         |
+| images      | Array  | `[]`                                                                                                    | Merge signature with the provide images. | `['A.png', 'B.png', 'C.png']` or `[{ src: 'A.png', x: 0, y: 0 }, { src: 'B.png', x: 0, y: 10 }, { src: 'C.png', x: 0, y: 20 }]` |
+| customStyle | Object | `{}`                                                                                                    | Custom `div` style.                      | `{ border: black 3px solid }`                                                                                                   |
 
 ## Methods
 
 | Name                                   | Argument Type                | Description                                                                 |
 | :------------------------------------- | :--------------------------- | --------------------------------------------------------------------------- |
-| `saveSignature()`                      | -                            | Will return target canvas **status** and **data**.                          |
+| `saveSignature(type, encoderOptions)`  | `(String, Number)`           | Will return target canvas **status** and **data**.                          |
 | `undoSignature()`                      | -                            | Undo                                                                        |
 | `clearSignature()`                     | -                            | Clear                                                                       |
 | `mergeImageAndSignature(signature)`    | `Object` or `String`         | Provide `images` as props and will merge with signature.                    |
@@ -108,11 +103,10 @@ export default {
 | `openSignaturePad()`                   | -                            | Open target signature pad.                                                  |
 | `getPropImagesAndCacheImages()`        | -                            | Get all the images information.                                             |
 | `clearCacheImages()`                   | -                            | Clear cache images.                                                         |
-| `fromDataURL(data, options, callback)` | `(String, Object, callback)` | Draw image from data URL.                                                   |
+| `fromDataURL(data, options, callback)` | `(String, Object, Callback)` | Draw image from data URL.                                                   |
 | `fromData(data)`                       | `String`                     | Returns signature image as an array of point groups.                        |
 | `toData()`                             | -                            | Draws signature image from an array of point groups.                        |
 | `isEmpty()`                            | -                            | Return signature canvas have data.                                          |
-
 
 ## Credits
 

--- a/src/components/VueSignaturePad.js
+++ b/src/components/VueSignaturePad.js
@@ -3,6 +3,7 @@ import mergeImages from 'merge-images';
 import {
   DEFAULT_OPTIONS,
   TRANSPARENT_PNG,
+  IMAGE_TYPES,
   checkSaveType,
   convert2NonReactive
 } from '../utils/index';
@@ -20,10 +21,6 @@ export default {
     },
     customStyle: {
       type: Object
-    },
-    saveType: {
-      type: String,
-      default: 'image/png'
     },
     options: {
       type: Object,
@@ -74,12 +71,15 @@ export default {
       this.signatureData = TRANSPARENT_PNG;
       this.signaturePad.fromData(data);
     },
-    saveSignature() {
-      const { signaturePad, saveType } = this;
+    saveSignature(type = IMAGE_TYPES[0], encoderOptions) {
+      const { signaturePad } = this;
       const status = { isEmpty: false, data: undefined };
 
-      if (!checkSaveType(saveType)) {
-        throw new Error('Image type is incorrect!');
+      if (!checkSaveType(type)) {
+        const imageTypesString = IMAGE_TYPES.join(', ');
+        throw new Error(
+          `The Image type is incorrect! We are support ${imageTypesString} types.`
+        );
       }
 
       if (signaturePad.isEmpty()) {
@@ -88,7 +88,7 @@ export default {
           isEmpty: true
         };
       } else {
-        this.signatureData = signaturePad.toDataURL(saveType);
+        this.signatureData = signaturePad.toDataURL(type, encoderOptions);
 
         return {
           ...status,

--- a/src/components/__tests__/VueSignatruePad.spec.js
+++ b/src/components/__tests__/VueSignatruePad.spec.js
@@ -21,13 +21,9 @@ describe('VueSignaturePad Component', () => {
   });
 
   it('should be throw incorrect image error message', () => {
-    const addOptionsWrapper = shallowMount(VueSignaturePad, {
-      propsData: {
-        saveType: 'text/html'
-      }
-    });
+    const addOptionsWrapper = shallowMount(VueSignaturePad);
 
-    expect(() => addOptionsWrapper.vm.saveSignature()).toThrow();
+    expect(() => addOptionsWrapper.vm.saveSignature('text/html')).toThrow();
   });
 
   it('should be return empty status and undefined data', () => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
-const SAVE_TYPE = ['image/png', 'image/jpeg', 'image/svg+xml'];
+export const IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/svg+xml'];
 
-export const checkSaveType = type => SAVE_TYPE.includes(type);
+export const checkSaveType = type => IMAGE_TYPES.includes(type);
 
 export const DEFAULT_OPTIONS = {
   dotSize: (0.5 + 2.5) / 2,


### PR DESCRIPTION
fixes: #204 

Remove default `saveType` props from the component, you can custom save type by `saveSignature` method, the default save type is `image/png`.